### PR TITLE
Short circuit check for component definition

### DIFF
--- a/src/angular-component.js
+++ b/src/angular-component.js
@@ -13,6 +13,8 @@
   function module() {
 
     var hijacked = ng.apply(this, arguments);
+    
+    if (angular.isDefined(hijacked.component)) return hijacked;
 
     function component(name, options) {
 


### PR DESCRIPTION
We have a directive library that supports multiple AngularJS versions (1.3+). We would like to include your code without worrying about overwriting angular 1.5's implementation by accident when people upgrade their angular version.
