### PR TITLE
Fixed closure error with loops

### DIFF
--- a/src/angular-component.js
+++ b/src/angular-component.js
@@ -122,19 +122,19 @@
               if (oneWayQueue.length) {
                 var destroyQueue = [];
                 for (var q = oneWayQueue.length; q--;) {
-				  (function(current){
-					  var unbindParent = $scope.$parent.$watch($attrs[current.attr], function (newValue, oldValue) {
-						self[current.local] = newValue;
-						updateChangeListener(current.local, newValue, oldValue, true);
-					  });
-					  destroyQueue.unshift(unbindParent);
-					  var unbindLocal = $scope.$watch(function () {
-						return self[current.local];
-					  }, function (newValue, oldValue) {
-						updateChangeListener(current.local, newValue, oldValue, false);
-					  });
-					  destroyQueue.unshift(unbindLocal);
-				  })(oneWayQueue[q]);
+                  (function(current){
+                    var unbindParent = $scope.$parent.$watch($attrs[current.attr], function (newValue, oldValue) {
+                      self[current.local] = newValue;
+                      updateChangeListener(current.local, newValue, oldValue, true);
+                    });
+                    destroyQueue.unshift(unbindParent);
+                    var unbindLocal = $scope.$watch(function () {
+                      return self[current.local];
+                    }, function (newValue, oldValue) {
+                      updateChangeListener(current.local, newValue, oldValue, false);
+                    });
+                    destroyQueue.unshift(unbindLocal);
+                  })(oneWayQueue[q]);
                 }
                 $scope.$on('$destroy', function () {
                   for (var i = destroyQueue.length; i--;) {

--- a/src/angular-component.js
+++ b/src/angular-component.js
@@ -122,18 +122,19 @@
               if (oneWayQueue.length) {
                 var destroyQueue = [];
                 for (var q = oneWayQueue.length; q--;) {
-                  var current = oneWayQueue[q];
-                  var unbindParent = $scope.$parent.$watch($attrs[current.attr], function (newValue, oldValue) {
-                    self[current.local] = newValue;
-                    updateChangeListener(current.local, newValue, oldValue, true);
-                  });
-                  destroyQueue.unshift(unbindParent);
-                  var unbindLocal = $scope.$watch(function () {
-                    return self[current.local];
-                  }, function (newValue, oldValue) {
-                    updateChangeListener(current.local, newValue, oldValue, false);
-                  });
-                  destroyQueue.unshift(unbindLocal);
+				  (function(current){
+					  var unbindParent = $scope.$parent.$watch($attrs[current.attr], function (newValue, oldValue) {
+						self[current.local] = newValue;
+						updateChangeListener(current.local, newValue, oldValue, true);
+					  });
+					  destroyQueue.unshift(unbindParent);
+					  var unbindLocal = $scope.$watch(function () {
+						return self[current.local];
+					  }, function (newValue, oldValue) {
+						updateChangeListener(current.local, newValue, oldValue, false);
+					  });
+					  destroyQueue.unshift(unbindLocal);
+				  })(oneWayQueue[q]);
                 }
                 $scope.$on('$destroy', function () {
                   for (var i = destroyQueue.length; i--;) {


### PR DESCRIPTION
Example code to reproduce:

.....
.component('parentCmp', {
      template: '<button ng-click="$ctrl.click()">updateChild</button><child-cmp first-bind="$ctrl.firstBind" second-bind="$ctrl.secondBind"></child-cmp>',
      controller: function() {
            this.click = function() {
                  this.firstBind = { title: 'bindOne' };
                  this.secondBind = { title: 'bindTwo' };
            }
      }
})
.component('childCmp', {
      bindings: {
            firstBind: '<',
            secondBind: '<'
      },
      controller: function() {
            this.$onChanges = function(changesObj) {
                  console.log(changesObj); // There is always only "secondBind".
            }
      }
});
